### PR TITLE
FEAT: Setup Home page and Page with slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,7 @@ group :development do
   # gem "spring"
 end
 
+group :test do
+  gem "capybara"
+  gem "webdrivers"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,12 +75,23 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
     bigdecimal (3.1.6)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -121,6 +132,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.22.2)
     msgpack (1.7.2)
@@ -150,6 +162,7 @@ GEM
     pg (1.5.6)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -197,8 +210,10 @@ GEM
       redis-client (>= 0.17.0)
     redis-client (0.21.0)
       connection_pool
+    regexp_parser (2.9.0)
     reline (0.4.3)
       io-console (~> 0.5)
+    rexml (3.2.6)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)
@@ -216,6 +231,11 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.13.1)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shoulda-matchers (6.1.0)
       activesupport (>= 5.2.0)
     sprockets (4.2.1)
@@ -241,10 +261,17 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.3.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webrick (1.8.1)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.13)
 
 PLATFORMS
@@ -257,6 +284,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  capybara
   cssbundling-rails
   debug
   factory_bot_rails
@@ -273,6 +301,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,5 @@
+class HomeController < ApplicationController
+  def index
+    @pages = Page.published.ordered
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,5 @@
+class PagesController < ApplicationController
+  def show
+    @page = Page.published.find_by(slug: params[:slug])
+  end
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,0 +1,2 @@
+module PagesHelper
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,6 +6,9 @@ class Page < ApplicationRecord
 
   before_validation :make_slug
 
+  scope :published, -> { where(published: true) }
+  scope :ordered, -> { order(created_at: :desc) }
+
   private
 
   def make_slug

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,5 @@
+<% @pages.each do |page| %>
+  <article>
+    <h2><%= page.title %></h2>
+  </article>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <%= render "shared/header" %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,0 +1,3 @@
+<article>
+  <h2><%= @page.title %></h2>
+</article>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,3 @@
+<header>
+  <%= link_to "My Blog", root_path %>
+</header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get 'pages/show'
+  root "home#index"
+  get "page/:slug", to: "pages#show", slug: /[-a-z0-9+]*/, as: :page
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -8,4 +8,8 @@ FactoryBot.define do
     created_at { Time.zone.now }
     published { false }
   end
+
+  trait :published do
+    published { true }
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -10,12 +10,25 @@ RSpec.describe Page, type: :model do
     it { is_expected.to validate_uniqueness_of(:title) }
     it { is_expected.to validate_presence_of(:content) }
   end
-  
+
   describe "#slug" do
     let(:page) { create(:page, title: '--Foo Bar! _ 87 --') }
 
     it "is generated from the title" do
       expect(page.slug).to eq("foo-bar-87")
+    end
+  end
+
+  describe ".ordered" do
+    let(:page1) { create(:page, created_at: 2.days.ago) }
+    let(:page2) { create(:page, created_at: 1.days.ago) }
+
+    before do
+      [page1, page2]
+    end
+
+    it "returns ordered pages" do
+      expect(Page.ordered).to eq([page2, page1])
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,12 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
+  config.before(:each, type: :system) do
+    driver = :selenium_chrome_headless
+    driver = :selenium_chrome if ENV["SHOW_CHROME"]
+    driven_by(driver)
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get root_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "Pages", type: :request do
+  describe "GET /show" do
+    let(:page) { create(:page, :published) }
+
+    it "returns http success" do
+      get page_path(slug: page.slug)
+      expect(response).to be_successful
+    end
+  end
+
+end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Home" do
+  it "renders homepage" do
+    create(:page, :published)
+
+    visit root_path
+
+    within "header" do
+      expect(page).to have_link "My Blog"
+    end
+
+    articles = find_all("article")
+    expect(articles.size).to eq(1)
+
+    within articles.first do
+      expect(page).to have_css("h2", text: Page.last.title)
+    end
+  end
+
+  describe "scopes" do
+    describe ".published" do
+      let(:page1) { create(:page, :published) }
+      let(:page2) { create(:page) }
+
+      before do
+        [page1, page2]
+      end
+
+      it "returns only published pages" do
+        expect(Page.published).to eq([page1])
+      end
+    end
+  end
+end

--- a/spec/system/page_spec.rb
+++ b/spec/system/page_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Pages" do
+  let(:my_page) { create(:page, :published) }
+
+  it "renders page" do
+    visit page_path(slug: my_page.slug)
+
+    article = find("article")
+
+    within article do
+      expect(page).to have_css("h2", text: my_page.title)
+    end
+  end
+end


### PR DESCRIPTION
Home
- Implement system test for root page
- Install capybara and webdrivers gem for system test
- Add home controller and views
- Add and render header partial to share across views

Page
- Added pages controller with show action
- Set up pages with slug route
- Added published and orded scopes to model
- Added published trait to factory for published: true

Other
- removed execissive helper and views tests